### PR TITLE
Allow Symfony 8 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
 
     "require": {
         "php":                   "^7.4|^8.0",
-        "symfony/css-selector":  "^4.4|^5.0|^6.0|^7.0"
+        "symfony/css-selector":  "^4.4|^5.0|^6.0|^7.0|^8.0"
     },
 
     "require-dev": {
-        "symfony/phpunit-bridge": "^5.2|^6.0|^7.0"
+        "symfony/phpunit-bridge": "^5.2|^6.0|^7.0|^8.0"
     },
 
     "replace": {


### PR DESCRIPTION
Add `^8.0` to `symfony/css-selector` and `symfony/phpunit-bridge` constraints to allow installation with Symfony 8.

This unblocks projects upgrading to Symfony 8 (e.g. Sylius — see https://github.com/Sylius/Sylius/issues/18760).